### PR TITLE
Add termrk:show as activationCommand

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.18",
   "description": "Terminal panel inside Atom",
   "activationCommands": {
-    "atom-workspace": "termrk:toggle"
+    "atom-workspace": [ "termrk:toggle", "termrk:show" ]
   },
   "repository": "https://github.com/romgrk/termrk",
   "license": "MIT",


### PR DESCRIPTION
I like to use the `termrk:show` command instead of `termrk:toggle` to show the terminal (I use separate keybindings for showing and hiding). Problem is that before `termrk:toggle` has been called the `termrk:show` command does nothing. This change should fix that.
