### PR TITLE
Add swi-prolog to programsByExtname

### DIFF
--- a/lib/termrk.coffee
+++ b/lib/termrk.coffee
@@ -20,6 +20,7 @@ programsByExtname =
     '.py':     'python'
     '.py3':    'python3'
     '.coffee': 'coffee'
+    '.pl':     'swipl'
 
 module.exports = Termrk =
 


### PR DESCRIPTION
I use Swi-Prolog a lot at University, and it would make my life so much easier if Termrk would support running Prolog code.
