### PR TITLE
Custom colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.4
+* add setting `terminalColors`
+
 ## 0.2.3
 * more efficient internal views management
 * added options: transisitionEasing and transitionDuration

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -70,6 +70,31 @@ class TermrkConfig
             type:        'integer'
             default:     250
 
+        'terminalColors':
+            title:       'Terminal colors'
+            type:        'array'
+            default:     [
+                             # dark:
+                             '#000000' # black
+                             '#cd0000' # red3
+                             '#00cd00' # green3
+                             '#cdcd00' # yellow3
+                             '#0000ee' # blue2
+                             '#cd00cd' # magenta3
+                             '#00cdcd' # cyan3
+                             '#e5e5e5' # gray90
+                             # bright:
+                             '#7f7f7f' # gray50
+                             '#ff0000' # red
+                             '#00ff00' # green
+                             '#ffff00' # yellow
+                             '#5c5cff' # rgb:5c/5c/ff
+                             '#ff00ff' # magenta
+                             '#00ffff' # cyan
+                             '#ffffff' # white
+                         ]
+            items:
+                type:    'string'
 
     constructor: (packageName) ->
         @prefix = packageName + '.'

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -72,6 +72,12 @@ class TermrkConfig
 
         'terminalColors':
             title:       'Terminal colors'
+            description: 'The colors to be substituted for the \\x1b[XXm ' +
+                         'escape sequences. The first 8 values represent ' +
+                         'the dim colors, the next 8 are optional and ' +
+                         'represent the bright/bold values and the last 2, ' +
+                         'also optional, are the default background and ' +
+                         'foreground colors.'
             type:        'array'
             default:     [
                              # dark:

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -92,6 +92,10 @@ class TermrkConfig
                              '#ff00ff' # magenta
                              '#00ffff' # cyan
                              '#ffffff' # white
+                             # background
+                             '#000000'
+                             # foreground
+                             '#f0f0f0'
                          ]
             items:
                 type:    'string'

--- a/lib/termjs-fix.coffee
+++ b/lib/termjs-fix.coffee
@@ -51,8 +51,8 @@ class Terminal extends termjs.Terminal
         @element.setAttribute('tabindex', 0)
 
         # This allows user to set terminal style in CSS
-        @colors[256] = @element.style.backgroundColor
-        @colors[257] = @element.style.color
+        @element.style.backgroundColor = @colors[256]
+        @element.style.color = @colors[257]
 
         # Create the lines for our terminal.
         @children = []

--- a/lib/termrk-view.coffee
+++ b/lib/termrk-view.coffee
@@ -92,6 +92,7 @@ class TermrkView extends View
             cols: @options.cols
             rows: @options.rows
             name: @options.name
+            colors: Config.terminalColors
         @termjs.open @element
 
         @attachListeners()

--- a/lib/termrk-view.coffee
+++ b/lib/termrk-view.coffee
@@ -282,19 +282,19 @@ class TermrkView extends View
 
     # Public: set colors from config
     updateColors: (oldValue, newValue) =>
-        # replace currently visible colors
-        for color, i in newValue
-            @find("[style*=\"#{oldValue[i]}\"], [data-color=\"#{oldValue[i]}\"]")
-                .css {color}
-                .attr 'data-color', color
-
         # update colors array on @termjs
         length = newValue.length
-        @termjs.colors = if length % 8 is 0
-            newValue.concat @termjs.colors.slice(length)
+        if length % 8 is 0
+            @termjs.colors = newValue.concat @termjs.colors.slice(length)
         else
-            newValue.slice(0, -2).concat(@termjs.colors.slice(length - 2, -2))
-                .concat(newValue.slice(-2))
+            @termjs.colors = newValue.slice(0, -2).concat(
+                @termjs.colors.slice(length - 2, -2), newValue.slice(-2))
+            @find('.terminal').css
+                'background-color': newValue[length - 2]
+                'color'           : newValue[length - 1]
+
+        # refresh
+        @termjs.refresh 0, @termjs.rows
 
     # Public: returns [cols, rows] for the given width and height
     calculateTerminalDimensions: (width, height) ->

--- a/lib/termrk-view.coffee
+++ b/lib/termrk-view.coffee
@@ -44,6 +44,12 @@ class TermrkView extends View
         @instances.forEach (instance) ->
             instance.updateFont.call(instance)
 
+    @colorsChanged: ({oldValue, newValue}) =>
+        return unless newValue.length is 8 or newValue.length is 16 or
+            newValue.length is 10 or newValue.length is 18
+        @instances.forEach (instance) ->
+            instance.updateColors(oldValue, newValue)
+
     ###
     Section: instance
     ###
@@ -273,6 +279,22 @@ class TermrkView extends View
         @css 'font', computedFont
 
         @updateTerminalSize()
+
+    # Public: set colors from config
+    updateColors: (oldValue, newValue) =>
+        # replace currently visible colors
+        for color, i in newValue
+            @find("[style*=\"#{oldValue[i]}\"], [data-color=\"#{oldValue[i]}\"]")
+                .css {color}
+                .attr 'data-color', color
+
+        # update colors array on @termjs
+        length = newValue.length
+        @termjs.colors = if length % 8 is 0
+            newValue.concat @termjs.colors.slice(length)
+        else
+            newValue.slice(0, -2).concat(@termjs.colors.slice(length - 2, -2))
+                .concat(newValue.slice(-2))
 
     # Public: returns [cols, rows] for the given width and height
     calculateTerminalDimensions: (width, height) ->

--- a/lib/termrk.coffee
+++ b/lib/termrk.coffee
@@ -98,6 +98,7 @@ module.exports = Termrk =
         @subscriptions.add Config.observe
             'fontSize':   -> TermrkView.fontChanged()
             'fontFamily': -> TermrkView.fontChanged()
+            'terminalColors': (values) -> TermrkView.colorsChanged(values)
 
         # Create elements and activate
         @setupElements()

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "pty.js": "0.3.0",
     "season": "^5.3.0",
     "space-pen": "^5.1.1",
-    "term.js": "0.0.4",
+    "term.js": "0.0.7",
     "underscore-plus": "^1.6.6"
   }
 }


### PR DESCRIPTION
This PR adds the `terminalColors` setting. It is an array of 8, 10, 16 or 18 CSS color strings that is passed directly to the `Terminal` constructor as the `colors` option. The first 8 colors are used for the `\x1b[0;XXm` escape characters where `XX = [ 30 .. 37 ]`. If 8 other colors are present, those are used for the `\x1b[1;XXm` escape characters. In both cases, if 2 more colors are present they will be used as background and foreground color, in that order.

It doesn't validate if the entries of the array are valid color strings. One way around this is to let Atom's `Config` class do this, but currently Atom doesn't support an array of colors as the config type. (It accepts it and returns the correct array, but it shows nothing in the settings view). That, in turn, could be solved by switching from an array of colors to an object with colors, but then we'd lose the order of the colors.

I upgraded term.js because there was a bug in v0.0.4 when the colors array had 18 entries.
