### PR TITLE
Add hide on exit setting

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -32,6 +32,11 @@ class TermrkConfig
             description: 'Restarts the shell as soon as it is terminated.'
             type: 'boolean'
             default: 'true'
+        'hideOnExit':
+            title: 'Hide on exit'
+            description: 'Hides the terminal when the shell is terminated.'
+            type: 'boolean'
+            default: 'false'
 
         # User options
         'userCommandsFile':

--- a/lib/termrk-view.coffee
+++ b/lib/termrk-view.coffee
@@ -79,6 +79,9 @@ class TermrkView extends View
     onDidResize: (callback) ->
         @emitter.on 'resize', callback
 
+    onDidExitProcess: (callback) ->
+        @emitter.on 'exit', callback
+
     ###
     Section: init/setup
     ###
@@ -219,6 +222,7 @@ class TermrkView extends View
         @model.destroy()
         delete @model
 
+        @emitter.emit 'exit', event
         if Config.restartShell
             @start()
         else

--- a/lib/termrk.coffee
+++ b/lib/termrk.coffee
@@ -106,6 +106,10 @@ module.exports = Termrk =
         view = @createTerminal()
         @setActiveTerminal(view)
 
+        @subscriptions.add view.onDidExitProcess (code, signal) =>
+            if Config.hideOnExit
+                @hide()
+
         window.termrk = @ if window.debug == true
 
     setupElements: ->


### PR DESCRIPTION
Users of standalone terminals may have the habit of exiting their shell to close the terminal (typically with ctrl-D). This patch adds a setting to make this work in Termrk.