### PR TITLE
Override ctrl-w by default

### DIFF
--- a/keymaps/terminal.cson
+++ b/keymaps/terminal.cson
@@ -36,3 +36,4 @@
     'ctrl-u':    'native!'
     'ctrl-x':    'native!'
     'ctrl-y':    'native!'
+    'ctrl-w':    'native!'

--- a/keymaps/terminal.cson
+++ b/keymaps/terminal.cson
@@ -37,3 +37,4 @@
     'ctrl-x':    'native!'
     'ctrl-y':    'native!'
     'ctrl-w':    'native!'
+    'ctrl-z':    'native!'


### PR DESCRIPTION
Ctrl-w deletes a word in a legacy terminal, and having it close
editor tabs instead when used out of habit can be disruptive.