### PR TITLE
Use active file's project folder

### DIFF
--- a/lib/termrk-model.coffee
+++ b/lib/termrk-model.coffee
@@ -57,7 +57,7 @@ class TermrkModel
         _.extend @options, options
 
         @options.shell ?= Config.getDefaultShell()
-        @options.cwd   ?= Config.getStartingDir()
+        @options.cwd    = Config.getStartingDir()
         @options.cols  ?= 200 # avoids init messages being cropped FIXME
         @options.rows  ?= 24
         @options.parameters ?= Config.getDefaultParameters()

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -51,7 +51,11 @@ Utils =
         OS.tmpdir()
 
     getProjectDir: ->
-        atom.project.getPaths()[0] ? Fs.getHomeDirectory()
+        filepath = atom.workspace.getActivePaneItem()?.buffer?.file?.path
+        if filepath?
+            atom.project.relativizePath(filepath)[0]
+        else
+            atom.project.getPaths()[0] ? Fs.getHomeDirectory()
 
     getCurrentDir: ->
         editor = atom.workspace.getActiveTextEditor()


### PR DESCRIPTION
Currently if config.startingDir is 'project' and multiple project
folders are open in the current window, the root of the project at the
top of the list when first launched is always used.

If the user edits a file from another project, this may not be
desirable. If the file is part of a Node.js package, for example, the
user may need to run Node Package Manager (npm) commands from the
file's project root, and similarly for git commands. This patch
updates the 'project' setting to check the project root of the
currently open file, falling back to the old behavior if no such file
is open.

Since the active file can change, we re-evaluate the starting directory
each time a shell process is spawned instead of permanently storing it
in @options.cwd with the existential assignment operator. That way, we
can open a file and then terminate our shell in order to open a fresh
shell in the new file's project root.