### PR TITLE
Expose the main focus event on the panel

### DIFF
--- a/lib/termrk.coffee
+++ b/lib/termrk.coffee
@@ -118,6 +118,7 @@ module.exports = Termrk =
 
     setupElements: ->
         @containerView = @createContainer()
+        @containerView.focus = -> Termrk.focus()
 
         @panel = atom.workspace.addBottomPanel(
             item: @containerView


### PR DESCRIPTION
Hey @romgrk, I was hoping you could take a look at this and send me some feedback. I'd like to use Termrk with @ktosiek's [focus-follows-mouse](https://github.com/ktosiek/focus-follows-mouse) (since I'm used to that behavior from my usual operating system environment). That package uses panel.getItem().focus() as a standard access point to set the focus to the contents of a panel on mouseover, which works fine with the tree-view and the find-and-replace box.

However, with Termrk, this calls into Termrk.containerView.focus(), which I think does nothing because it's just a jQuery'd wrapper div around the actual content. In practice this means mouseover sets focus for every other part of Atom except for Termrk, which still requires a click. To fix that, I want to wire up an event handler on the containerView that calls Termrk.focus() somehow.

All of my attempts to addEventListener('focus') or on('focus') were unsuccessful; my code was never called when ktosiek/focus-follows-mouse made its call to panel.getItem().focus(). Finally I tried what I knew was a hack, and unfortunately it worked. Instead of going through the proper DOM event structure, I just defined a new 'focus' property on containerView with its value a function that makes the needed call. This is the change in this PR, which I am providing for illustration and feedback rather than necessarily for merging. I'm not happy with this solution; disregarding the DOM event system is bad enough in itself, but I'm also concerned that this could cause problems if jQuery doesn't like me adding random new properties to its objects.

What do you think would be a good way to solve this? Is there a way to handle containerView's focus event that would work more reliably? I could also send a PR to ktosiek/focus-follows-mouse if there's a better call it could use. Please let me know if you have great ideas about this!